### PR TITLE
[day12-memory] 백경만

### DIFF
--- a/day12-memory/submissions/bgm.py
+++ b/day12-memory/submissions/bgm.py
@@ -1,0 +1,242 @@
+"""
+단기 메모리(Short-term): 에이전트의 state에 넣어, 여러 턴 대화를 가능하게 함
+같은 thread 안에서만 이어지는 기억 (대화 히스토리 같은 것)
+
+장기 메모리(Long-term): 세션이 바뀌어도 유지되는 사용자별 / 앱 전체 데이터를 저장
+thread가 달라도 유지되는 기억 (유저 프로필/선호/설정 같은 것)
+"""
+
+#---------------------------------------
+#Add short-term memory
+#---------------------------------------
+# # use in production (postgres, mongodb, redis)
+from dotenv import load_dotenv
+load_dotenv()
+
+#use in subgraphs
+#서브그래프의 메모리는 기본적으로 부모 그래프가 관리, 필요하면 서브그래프만 따로 독립 메모리를 가질 수 있음 > 멀티에이전트
+from langgraph.graph import START, StateGraph
+from langgraph.checkpoint.memory import InMemorySaver
+from typing import TypedDict
+from langgraph.types import Command, interrupt
+
+class State(TypedDict):
+    foo: str
+
+# Subgraph
+def subgraph_node_1(state: State):
+    answer = interrupt({"question": "continue?"})
+    return {"foo": state["foo"] + answer}
+
+subgraph_builder = StateGraph(State)
+subgraph_builder.add_node(subgraph_node_1)
+subgraph_builder.add_edge(START, "subgraph_node_1")
+subgraph = subgraph_builder.compile()
+# subgraph = subgraph_builder.compile(checkpointer=True) # 부모 그래프와 별도로 메모리를 관리할 수 있음     
+
+# Parent graph
+builder = StateGraph(State)
+builder.add_node("subgraph_node_1", subgraph)
+builder.add_edge(START, "subgraph_node_1")
+
+checkpointer = InMemorySaver()
+graph = builder.compile(checkpointer=checkpointer)
+
+config = {
+    "configurable": {
+        "thread_id": "1"
+    }
+}
+
+result = graph.invoke({"foo": "a"}, config)
+print(result["__interrupt__"])
+
+graph.invoke(Command(resume="X"), config)
+
+history = list(graph.get_state_history(config))
+
+subgraph_namespaces = set()
+
+for snap in history:
+    for task in snap.tasks or []:
+        state = task.state
+        if state and "checkpoint_ns" in state.get("configurable", {}):
+            subgraph_namespaces.add(
+                state["configurable"]["checkpoint_ns"]
+            )
+
+for ns in subgraph_namespaces:
+    sub_config = {
+        "configurable": {
+            "thread_id": "1",
+            "checkpoint_ns": ns
+        }
+    }
+
+    print(f"\n--- subgraph memory: {ns} ---")
+    print(list(graph.get_state_history(sub_config)))
+
+
+#---------------------------------------
+#Manage short-term memory (LLM에 매 호출마다 그대로 들어가, 토큰 제한에 걸릴 수 있음)
+#---------------------------------------
+
+##1. Trim ##
+print("\n========trim=========\n")
+from langchain_core.messages.utils import (
+    trim_messages,  
+    count_tokens_approximately  
+)
+from langchain.chat_models import init_chat_model
+from langgraph.graph import StateGraph, START, MessagesState
+from langgraph.checkpoint.memory import InMemorySaver 
+
+model = init_chat_model("gpt-5-nano")
+
+def call_model(state: MessagesState):
+    messages = trim_messages(  
+        state["messages"],
+        strategy="last", #어디를 남길지(last: 마지막, first: 첫번째)
+        token_counter=count_tokens_approximately, #빠른 근사 토큰 계산
+        max_tokens=128, #결과 메시지들의 총 토큰 수 ≤ 128
+        start_on="human", #잘린 결과가 HumanMessage부터 시작
+        end_on=("human", "tool"), #어디까지 끝낼지(ToolMessage 뒤에 AI가 바로 오지 않게 정리)
+    )
+    # messages = state["messages"] #제한이 없으면 다 기억함
+    response = model.invoke(messages)
+    return {"messages": [response]}
+
+checkpointer = InMemorySaver()
+builder = StateGraph(MessagesState)
+builder.add_node(call_model)
+builder.add_edge(START, "call_model")
+graph = builder.compile(checkpointer=checkpointer)
+
+config = {"configurable": {"thread_id": "1"}}
+result1 = graph.invoke({"messages": "안녕 내 이름은 김철수야."}, config)
+result1["messages"][-1].pretty_print()
+
+result2 = graph.invoke({"messages": "고양이들에 대한 짧은 시를 작성해줘."}, config)
+result2["messages"][-1].pretty_print()
+
+result3 = graph.invoke({"messages": "같은 작업을 하는데, 강아지로 해줘."}, config)
+result3["messages"][-1].pretty_print()
+
+final_response = graph.invoke({"messages": "내 이름은 뭐야?"}, config)
+final_response["messages"][-1].pretty_print() #철수를 잊음
+
+print("\n", [(message.type, message.content) for message in final_response["messages"]])
+
+#2. Delete ##
+print("\n========delete=========\n")
+from langchain.messages import RemoveMessage  
+
+def delete_messages(state):
+    messages = state["messages"]
+    if len(messages) > 2:
+        print("\n==메시지 개수가 제한을 초과했습니다!==\n")
+        # remove the earliest two messages
+        return {"messages": [RemoveMessage(id=m.id) for m in messages[:2]]}  #RemoveMessage(id=REMOVE_ALL_MESSAGES) : 모든 메시지 삭제
+
+def call_model(state: MessagesState):
+    response = model.invoke(state["messages"])
+    return {"messages": response}
+
+builder = StateGraph(MessagesState)
+builder.add_sequence([call_model, delete_messages])
+builder.add_edge(START, "call_model")
+
+checkpointer = InMemorySaver()
+app = builder.compile(checkpointer=checkpointer)
+
+config = {"configurable": {"thread_id": "2"}}
+for event in app.stream(
+    {"messages": [{"role": "user", "content": "안녕! 난 영희야"}]},
+    config,
+    stream_mode="values"
+):
+    print("first invoke", [(message.type, message.content) for message in event["messages"]])
+
+for event in app.stream(
+    {"messages": [{"role": "user", "content": "내 이름이 뭐야?"}]},
+    config,
+    stream_mode="values"
+):
+    print("second invoke", [(message.type, message.content) for message in event["messages"]])
+
+# checkpointer.delete_thread(thread_id) #thread 삭제
+
+##3. Summarize ##
+# pip install langmem
+print("\n========summarize=========\n")
+from langgraph.graph import StateGraph, START
+from langgraph.graph import MessagesState
+from langgraph.checkpoint.memory import InMemorySaver
+
+from langchain.chat_models import init_chat_model
+from langchain.messages import HumanMessage, RemoveMessage
+
+model = init_chat_model("gpt-5-nano")
+
+class State(MessagesState):
+    summary: str
+
+# 요약 노드
+def summarize_conversation(state: State):
+    summary = state.get("summary", "")
+
+    if summary:
+        summary_message = (
+            f"This is a summary of the conversation to date:\n{summary}\n\n"
+            "Extend the summary by taking into account the new messages above:"
+        )
+    else:
+        summary_message = "Create a summary of the conversation above:"
+
+    messages = state["messages"] + [HumanMessage(content=summary_message)]
+    response = model.invoke(messages)
+
+    # 메시지 정리 (최근 2개만 유지)
+    delete_messages = [
+        RemoveMessage(id=m.id)
+        for m in state["messages"][:-2]
+    ]
+
+    return {
+        "summary": response.content,
+        "messages": delete_messages,
+    }
+
+
+def call_model(state: State):
+    messages = state["messages"]
+
+    if state.get("summary"):
+        messages = [
+            HumanMessage(
+                content=f"(Conversation summary)\n{state['summary']}"
+            )
+        ] + messages
+
+    response = model.invoke(messages)
+    return {"messages": [response]}
+
+builder = StateGraph(State)
+builder.add_node("summarize", summarize_conversation)
+builder.add_node("call_model", call_model)
+builder.add_edge(START, "call_model")
+builder.add_edge("call_model", "summarize")
+
+graph = builder.compile(checkpointer=InMemorySaver())
+
+config = {"configurable": {"thread_id": "1"}}
+
+graph.invoke({"messages": "안녕 내 이름은 김철수야"}, config)
+graph.invoke({"messages": "고양이에 대한 짧은 시를 써줘"}, config)
+graph.invoke({"messages": "강아지로 해줘"}, config)
+final = graph.invoke({"messages": "내 이름은 뭐야?"}, config)
+
+final["messages"][-1].pretty_print()
+print("\nSummary:", final["summary"])
+
+# print(f"\n\n ========history=========\n:{list(graph.get_state_history(config))}")


### PR DESCRIPTION
# PR 제목 규칙
- [day12-memory] 백경만

## 실습내역
- 기존 example.py를 현재 개발 중인 서비스에 맞게 변형하는 실습 진행하지 않음
- 아래와 같이 day11-timetravel 실습 내용과 비교하는 내용 작성으로 갈음함
```text
● Day 11 vs Day 12 비교 (체크포인트 & 서브그래프 관점)

  구조 비교

  │      항목              │     Day 11 (Time Travel)            │        Day 12 (Memory)             │ 
  │ 그래프 구조        │ 단일 그래프 (플랫)                     │ 부모 + 서브그래프 (중첩)          │ 
  │ 노드 수               │ 3개 (topic → joke → evaluate) │ 1개 (서브그래프 자체가 노드)    │ 
  │ 체크포인트 용도  │ 과거로 돌아가 분기(Fork)          │ 상태 저장 + 메모리 관리           │ 
  │ 핵심 기능            │ Time Travel, update_state       │ interrupt, resume, 메모리 전략 │ 
  ---
  체크포인트 관점

  Day 11: 단일 체크포인트 체인

  start → topic → joke → evaluate → END
                   ↓
            update_state로 분기
                   ↓
           topic="닭" → joke → evaluate → END
  - checkpoint_id 하나의 네임스페이스에서 관리
  - get_state_history(config)로 전체 이력 조회
  - update_state()로 과거 상태 수정 → 새 분기 생성

  Day 12: 부모/자식 체크포인트 분리

  부모 그래프: checkpoint_ns = ''
      └── 서브그래프: checkpoint_ns = 'subgraph_node_1:UUID'
  - checkpoint_map으로 부모-자식 관계 추적
  - 서브그래프는 독립적인 checkpoint_ns를 가짐
  - parents 필드로 어떤 부모 체크포인트에서 분기했는지 기록

  ---
  상태 변경 방식
  Day 11: update_state(config, values={"topic": "닭"})
  Day 12: Command(resume="X")
  ────────────────────────────────────────
  Day 11: 과거 시점으로 이동 후 값 덮어쓰기
  Day 12: interrupt 시점에서 사용자 입력 받아 재개
  ────────────────────────────────────────
  Day 11: 개발자가 직접 상태 조작
  Day 12: Human-in-the-loop 패턴
  ---
  코드 비교

  Day 11: 과거 상태 수정

  # 과거 체크포인트 선택
  selected_state = states[2]

  # 상태 값 변경 후 재실행
  new_config = graph.update_state(selected_state.config, values={"topic": "닭"})       
  result = graph.invoke(None, new_config)

  Day 12: interrupt/resume

  # 서브그래프에서 interrupt
  def subgraph_node_1(state: State):
      answer = interrupt({"question": "continue?"})  # 여기서 멈춤
      return {"foo": state["foo"] + answer}

  # 첫 실행 → interrupt에서 멈춤
  graph.invoke({"foo": "a"}, config)

  # resume으로 재개
  graph.invoke(Command(resume="X"), config)  # "a" + "X" = "aX"

  ---
  서브그래프 관점

  │     항목           │          Day 11                     │                Day 12                                  │ 
  │ 서브그래프     │ 없음                                  │ 있음 (subgraph_builder.compile())       │ 
  │ 네임스페이스  │ 단일                                  │ 부모 '' + 자식 '노드:UUID'                     │ 
  │ 메모리 독립성 │ N/A                                  │ checkpointer=True 옵션으로 독립 가능 │ 
  │ 이력 조회        │ get_state_history(config) │ 서브그래프용 checkpoint_ns 필요         │
  ---
  Day 12 추가 내용: 메모리 관리 전략

  Day 11에는 없고 Day 12에만 있는 내용:
  ┌───────────┬───────────────────────────────────────┐
  │   전략                   │                 설명                                                                              │
  ├───────────┼───────────────────────────────────────┤
  │ Trim                     │ 토큰 수 제한 (최근 N개 메시지만 유지)                                          │
  ├───────────┼───────────────────────────────────────┤
  │ Delete                  │ RemoveMessage로 오래된 메시지 삭제                                       │
  ├───────────┼───────────────────────────────────────┤
  │ Summarize          │ LLM으로 대화 요약 후 압축 저장                                                    │
  └───────────┴───────────────────────────────────────┘
  ---
  핵심 차이 요약

  Day 11: "과거로 돌아가서 다른 선택을 하면 어떻게 될까?" (Time Travel)
  Day 12: "대화가 길어지면 메모리를 어떻게 관리할까?" (Memory Management)

  - Day 11은 체크포인트를 디버깅/실험 도구로 활용
  - Day 12는 체크포인트를 상태 지속성 + 서브그래프 격리 도구로 활용
```
## 제출 task
- task 번호: day12-memory

## 한 줄 요약
- memory: LangGraph에서 InMemorySaver 체크포인터로 단기 메모리를 저장하고, 서브그래프는 부모 그래프가 메모리를 관리하며(필요시 독립 가능), interrupt()/Command(resume=)로     
  중단·재개하고, get_state_history()로 상태 히스토리를 조회 가능 / 최종 프로젝트에 서브그래프까지 적용 시켜야하는지 검토 필요

## 헷갈린 점 (선택)
- 없음
